### PR TITLE
Error running Getting Started code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ wget https://github.com/blacktop/docker-zeek/raw/master/pcap/heartbleed.pcap
 $ wget https://github.com/blacktop/docker-zeek/raw/master/3.0/local.zeek
 $ docker run --rm \
          -v `pwd`:/pcap \
-         -v `pwd`/local.zeek:/usr/local/zeek/share/zeek/site/local.zeek \  # All default modules loaded
+         -v `pwd`/local.zeek:/usr/local/zeek/share/zeek/site/local.zeek \
          blacktop/zeek -r heartbleed.pcap local "Site::local_nets += { 192.168.11.0/24 }"
 ```
 


### PR DESCRIPTION
   modified:   README.md

removed '# All default modules loaded' comment in Getting Started section of README

It throws

    'docker: invalid reference format.
     See 'docker run --help'.
     zsh: no such file or directory: blacktop/zeek'