### PR TITLE
Fix issue #21

### DIFF
--- a/elastic/Dockerfile
+++ b/elastic/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12 as builder
 
 LABEL maintainer "https://github.com/blacktop"
 
-ENV ZEEK_VERSION 3.2.3
+ENV ZEEK_VERSION 4.1.1
 
 RUN apk add --no-cache zlib openssl libstdc++ libpcap libgcc
 RUN apk add --no-cache -t .build-deps \


### PR DESCRIPTION
The Elastic Dockefile was having errors building af_packet and
community-id, this is because those repos have been updated to
zeek 4.

Using 4.1.1 works just fine.